### PR TITLE
Integrate xdg_shell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,7 @@ travis-ci = { repository = "Smithay/wayland-window" }
 byteorder = "1.0"
 tempfile = "2.0"
 wayland-client = { version = "0.9", features = ["cursor"] }
-wayland-protocols = { optional = true, version = "0.9", features = ["client", "unstable_protocols"] }
+wayland-protocols = { version = "0.9", features = ["client", "unstable_protocols"] }
 
 [dev-dependencies]
 wayland-client = { version = "0.9", features = ["cursor", "dlopen"] }
-
-[features]
-xdg_shell = ["wayland-protocols"]
-default = ["xdg_shell"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ travis-ci = { repository = "Smithay/wayland-window" }
 byteorder = "1.0"
 tempfile = "2.0"
 wayland-client = { version = "0.9", features = ["cursor"] }
+wayland-protocols = { optional = true, version = "0.9", features = ["client", "nightly", "unstable_protocols"] }
 
 [dev-dependencies]
 wayland-client = { version = "0.9", features = ["cursor", "dlopen"] }
+
+[features]
+xdg_shell = ["wayland-protocols"]
+default = ["xdg_shell"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ travis-ci = { repository = "Smithay/wayland-window" }
 byteorder = "1.0"
 tempfile = "2.0"
 wayland-client = { version = "0.9", features = ["cursor"] }
-wayland-protocols = { optional = true, version = "0.9", features = ["client", "nightly", "unstable_protocols"] }
+wayland-protocols = { optional = true, version = "0.9", features = ["client", "unstable_protocols"] }
 
 [dev-dependencies]
 wayland-client = { version = "0.9", features = ["cursor", "dlopen"] }

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -36,7 +36,7 @@ struct Window {
 }
 
 impl wayland_window::Handler for Window {
-    fn configure(&mut self, _: &mut EventQueueHandle, width: i32, height: i32) {
+    fn configure(&mut self, _: &mut EventQueueHandle, _conf: wayland_window::Configure, width: i32, height: i32) {
         let w = std::cmp::max(width, 100);
         let h = std::cmp::max(height, 100);
         if width <= 0 || height <= 0 {

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -38,7 +38,11 @@ impl wayland_window::Handler for Window {
     fn configure(&mut self, _: &mut EventQueueHandle, _conf: wayland_window::Configure, width: i32, height: i32) {
         let w = std::cmp::max(width, 100);
         let h = std::cmp::max(height, 100);
+        println!("configure: {:?}", (w, h));
         self.newsize = Some((w, h))
+    }
+    fn close(&mut self, _: &mut EventQueueHandle) {
+        println!("close window");
     }
 }
 

--- a/examples/simple_window.rs
+++ b/examples/simple_window.rs
@@ -70,7 +70,7 @@ fn main() {
     event_queue.register::<_, EnvHandler<WaylandEnv>>(&registry, 0);
     event_queue.sync_roundtrip().unwrap();
 
-    // Use XdgShell if its available. Otherwise, fall back to WlShell.
+    // Use `xdg-shell` if its available. Otherwise, fall back to `wl-shell`.
     let (mut xdg_shell, mut wl_shell) = (None, None);
     {
         let state = event_queue.state();

--- a/src/decorated_surface.rs
+++ b/src/decorated_surface.rs
@@ -529,6 +529,5 @@ pub fn add_borders(width: i32, height: i32) -> (i32, i32) {
 
 pub trait Handler {
     fn configure(&mut self, &mut EventQueueHandle, shell::Configure, width: i32, height: i32);
+    fn close(&mut self, &mut EventQueueHandle);
 }
-
-

--- a/src/decorated_surface.rs
+++ b/src/decorated_surface.rs
@@ -529,7 +529,19 @@ pub fn add_borders(width: i32, height: i32) -> (i32, i32) {
 }
 
 
+/// For handling events that occur to a DecoratedSurface.
 pub trait Handler {
+    /// Called whenever the DecoratedSurface has been resized.
+    ///
+    /// **Note:** `width` and `height` will not always be positive values. Values can be negative
+    /// if a user attempts to resize the window past the left or top borders. As a result, it is
+    /// recommended that users specify some reasonable bounds. E.g.
+    ///
+    /// ```ignore
+    /// let width = max(width, min_width);
+    /// let height = max(height, min_height);
+    /// ```
     fn configure(&mut self, &mut EventQueueHandle, shell::Configure, width: i32, height: i32);
+    /// Called when the DecoratedSurface is closed.
     fn close(&mut self, &mut EventQueueHandle);
 }

--- a/src/decorated_surface.rs
+++ b/src/decorated_surface.rs
@@ -378,8 +378,13 @@ impl<H: Handler> DecoratedSurface<H> {
     ///
     /// Automatically disables fullscreen mode if it was set.
     pub fn set_decorate(&mut self, decorate: bool) {
-        if let shell::Surface::Wl(ref surface) = self.shell_surface {
-            surface.set_toplevel();
+        match self.shell_surface {
+            shell::Surface::Wl(ref surface) => {
+                surface.set_toplevel();
+            },
+            shell::Surface::Xdg(ref surface) => {
+                surface.toplevel.unset_fullscreen();
+            },
         }
         self.decorate = decorate;
         // trigger redraw

--- a/src/decorated_surface.rs
+++ b/src/decorated_surface.rs
@@ -361,10 +361,16 @@ impl<H: Handler> DecoratedSurface<H> {
     /// belongs. A common convention is to use the file name (or the full path if it is a
     /// non-standard location) of the application's .desktop file as the class.
     ///
-    /// Note: This is ignored when using `xdg_shell`. Not sure if it should be handled.
+    /// When using xdg-shell, this calls `ZxdgTopLevelV6::set_app_id`.
+    /// When using wl-shell, this calls `WlShellSurface::set_class`.
     pub fn set_class(&self, class: String) {
-        if let shell::Surface::Wl(ref wl) = self.shell_surface {
-            wl.set_class(class);
+        match self.shell_surface {
+            shell::Surface::Xdg(ref xdg) => {
+                xdg.toplevel.set_app_id(class);
+            },
+            shell::Surface::Wl(ref wl) => {
+                wl.set_class(class);
+            },
         }
     }
 

--- a/src/decorated_surface.rs
+++ b/src/decorated_surface.rs
@@ -391,19 +391,15 @@ impl<H: Handler> DecoratedSurface<H> {
     ///
     /// Automatically disables decorations.
     ///
-    /// Note: When using `xdg_shell`, the requested `FullscreenMethod` and `framerate` will be
-    /// ignored. Not sure if some way of handling these arguments should be added to the xdg_shell?
-    pub fn set_fullscreen(
-        &mut self,
-        method: wl_shell_surface::FullscreenMethod,
-        framerate: u32,
-        output: Option<&wl_output::WlOutput>,
-    ) {
+    /// When using wl-shell, this uses the default fullscreen method and framerate.
+    pub fn set_fullscreen(&mut self, output: Option<&wl_output::WlOutput>) {
         match self.shell_surface {
             shell::Surface::Xdg(ref mut xdg) => {
                 xdg.toplevel.set_fullscreen(output);
             },
             shell::Surface::Wl(ref mut shell_surface) => {
+                let method = wl_shell_surface::FullscreenMethod::Default;
+                let framerate = 0; // Let the server decide the framerate.
                 shell_surface.set_fullscreen(method, framerate, output);
             },
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 extern crate byteorder;
 extern crate tempfile;
 extern crate wayland_client;
-#[cfg(feature = "xdg_shell")] extern crate wayland_protocols;
+extern crate wayland_protocols;
 
 mod decorated_surface;
 mod themed_pointer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //!     newsize = Some((x, y))
 //! }
 //! if let Some((x, y)) = newsize {
-//!     let (x, y) = substract_borders(x, y);
+//!     let (x, y) = subtract_borders(x, y);
 //!     window.resize(x, y);
 //! }
 //! ```
@@ -74,14 +74,15 @@
 //!   window to its current size (update the buffer to the compositor), as the compositer
 //!   might have resized your window without telling you.
 //! - The size hint provided by the compositor counts the borders size, to get the real
-//!   size hint for your interior surface, use the function `substract_borders(..)` provided
+//!   size hint for your interior surface, use the function `subtract_borders(..)` provided
 //!   by this library.
 
 extern crate byteorder;
 extern crate tempfile;
 extern crate wayland_client;
+#[cfg(feature = "xdg_shell")] extern crate wayland_protocols;
 
 mod decorated_surface;
 mod themed_pointer;
 
-pub use decorated_surface::{DecoratedSurface, substract_borders, add_borders, Handler};
+pub use decorated_surface::{DecoratedSurface, subtract_borders, add_borders, Handler};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,5 +84,7 @@ extern crate wayland_client;
 
 mod decorated_surface;
 mod themed_pointer;
+mod shell;
 
 pub use decorated_surface::{DecoratedSurface, subtract_borders, add_borders, Handler};
+pub use shell::{Configure, Shell};

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1,0 +1,54 @@
+use wayland_client::protocol::{wl_shell, wl_shell_surface, wl_surface};
+use wayland_protocols::unstable::xdg_shell;
+
+#[cfg(feature = "xdg_shell")]
+mod xdg;
+mod wl;
+
+pub enum Shell {
+    #[cfg(feature = "xdg_shell")]
+    Xdg(xdg_shell::client::zxdg_shell_v6::ZxdgShellV6),
+    Wl(wl_shell::WlShell),
+}
+
+pub enum Surface {
+    #[cfg(feature = "xdg_shell")]
+    Xdg(self::xdg::Surface),
+    Wl(wl_shell_surface::WlShellSurface),
+}
+
+/// Configure data for a decorated surface handler.
+pub enum Configure {
+    #[cfg(feature = "xdg_shell")]
+    Xdg,
+    Wl(wl_shell_surface::Resize),
+}
+
+impl Surface {
+
+    pub fn from_shell(surface: &wl_surface::WlSurface, shell: &Shell) -> Self {
+        match *shell {
+
+            // Create the `xdg_surface` and assign the `toplevel` role.
+            #[cfg(feature = "xdg_shell")]
+            Shell::Xdg(ref shell) => {
+                let xdg_surface = shell.get_xdg_surface(surface).expect("shell cannot be destroyed");
+                let toplevel = xdg_surface.get_toplevel().expect("xdg_surface cannot be destroyed");
+                surface.commit();
+                Surface::Xdg(self::xdg::Surface {
+                    surface: xdg_surface,
+                    toplevel: toplevel,
+                })
+            },
+
+            // Create a `wl_shell_surface` and set it as the `toplevel`.
+            Shell::Wl(ref shell) => {
+                let shell_surface = shell.get_shell_surface(surface);
+                shell_surface.set_toplevel();
+                Surface::Wl(shell_surface)
+            },
+
+        }
+    }
+
+}

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -1,25 +1,21 @@
 use wayland_client::protocol::{wl_shell, wl_shell_surface, wl_surface};
 use wayland_protocols::unstable::xdg_shell;
 
-#[cfg(feature = "xdg_shell")]
 mod xdg;
 mod wl;
 
 pub enum Shell {
-    #[cfg(feature = "xdg_shell")]
     Xdg(xdg_shell::client::zxdg_shell_v6::ZxdgShellV6),
     Wl(wl_shell::WlShell),
 }
 
 pub enum Surface {
-    #[cfg(feature = "xdg_shell")]
     Xdg(self::xdg::Surface),
     Wl(wl_shell_surface::WlShellSurface),
 }
 
 /// Configure data for a decorated surface handler.
 pub enum Configure {
-    #[cfg(feature = "xdg_shell")]
     Xdg,
     Wl(wl_shell_surface::Resize),
 }
@@ -30,7 +26,6 @@ impl Surface {
         match *shell {
 
             // Create the `xdg_surface` and assign the `toplevel` role.
-            #[cfg(feature = "xdg_shell")]
             Shell::Xdg(ref shell) => {
                 let xdg_surface = shell.get_xdg_surface(surface).expect("shell cannot be destroyed");
                 let toplevel = xdg_surface.get_toplevel().expect("xdg_surface cannot be destroyed");

--- a/src/shell/wl.rs
+++ b/src/shell/wl.rs
@@ -1,0 +1,53 @@
+use decorated_surface::{self, DecoratedSurface};
+use wayland_client::{self, EventQueueHandle};
+use wayland_client::protocol::wl_shell_surface;
+
+////////////////////////////////////////
+// wl_shell `Handler` implementations //
+////////////////////////////////////////
+
+
+impl<H> wl_shell_surface::Handler for DecoratedSurface<H>
+    where H: decorated_surface::Handler,
+{
+    fn ping(
+        &mut self,
+        _: &mut EventQueueHandle,
+        me: &wl_shell_surface::WlShellSurface,
+        serial: u32,
+    ) {
+        me.pong(serial);
+    }
+
+    fn configure(
+        &mut self,
+        evqh: &mut EventQueueHandle,
+        _: &wl_shell_surface::WlShellSurface,
+        edges: wl_shell_surface::Resize,
+        width: i32,
+        height: i32,
+    ) {
+        if let Some(handler) = decorated_surface::handler_mut(self) {
+            let (w, h) = decorated_surface::subtract_borders(width, height);
+            let configure = super::Configure::Wl(edges);
+            handler.configure(evqh, configure, w, h)
+        }
+    }
+}
+
+unsafe impl<H> wayland_client::Handler<wl_shell_surface::WlShellSurface> for DecoratedSurface<H>
+    where H: decorated_surface::Handler
+{
+    unsafe fn message(
+        &mut self,
+        evq: &mut EventQueueHandle,
+        proxy: &wl_shell_surface::WlShellSurface,
+        opcode: u32,
+        args: *const wayland_client::sys::wl_argument,
+    ) -> Result<(),()>
+    {
+        <DecoratedSurface<H> as wayland_client::protocol::wl_shell_surface::Handler>::__message(
+            self, evq, proxy, opcode, args
+        )
+    }
+}

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -1,5 +1,4 @@
 use decorated_surface::{self, DecoratedSurface};
-use std::cmp::max;
 use wayland_client::{self, EventQueueHandle};
 use wayland_protocols::unstable::xdg_shell;
 use wayland_protocols::unstable::xdg_shell::client::zxdg_toplevel_v6::ZxdgToplevelV6;

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -69,8 +69,10 @@ impl<H> xdg_shell::client::zxdg_toplevel_v6::Handler for DecoratedSurface<H>
         }
     }
 
-    fn close(&mut self, _evqh: &mut EventQueueHandle, _proxy: &ZxdgToplevelV6) {
-        // NOTE: Should there be a method on `Handler` for this?
+    fn close(&mut self, evqh: &mut EventQueueHandle, _proxy: &ZxdgToplevelV6) {
+        if let Some(handler) = decorated_surface::handler_mut(self) {
+            handler.close(evqh);
+        }
     }
 }
 

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -65,7 +65,7 @@ impl<H> xdg_shell::client::zxdg_toplevel_v6::Handler for DecoratedSurface<H>
         if let Some(handler) = decorated_surface::handler_mut(self) {
             let (w, h) = decorated_surface::subtract_borders(width, height);
             let configure = super::Configure::Xdg;
-            handler.configure(evqh, configure, max(w, 1), max(h, 1));
+            handler.configure(evqh, configure, w, h);
         }
     }
 

--- a/src/shell/xdg.rs
+++ b/src/shell/xdg.rs
@@ -1,0 +1,92 @@
+use decorated_surface::{self, DecoratedSurface};
+use std::cmp::max;
+use wayland_client::{self, EventQueueHandle};
+use wayland_protocols::unstable::xdg_shell;
+use wayland_protocols::unstable::xdg_shell::client::zxdg_toplevel_v6::ZxdgToplevelV6;
+use wayland_protocols::unstable::xdg_shell::client::zxdg_surface_v6::ZxdgSurfaceV6;
+
+pub struct Surface {
+    pub toplevel: ZxdgToplevelV6,
+    pub surface: ZxdgSurfaceV6,
+}
+
+
+/////////////////////////////////////////
+// xdg_shell `Handler` implementations //
+/////////////////////////////////////////
+
+
+unsafe impl<H> wayland_client::Handler<ZxdgToplevelV6> for DecoratedSurface<H>
+    where H: decorated_surface::Handler,
+{
+    unsafe fn message(
+        &mut self,
+        evq: &mut EventQueueHandle,
+        proxy: &ZxdgToplevelV6,
+        opcode: u32,
+        args: *const wayland_client::sys::wl_argument,
+    ) -> Result<(),()>
+    {
+        <DecoratedSurface<H> as xdg_shell::client::zxdg_toplevel_v6::Handler>::__message(
+            self, evq, proxy, opcode, args
+        )
+    }
+}
+
+unsafe impl<H> wayland_client::Handler<ZxdgSurfaceV6> for DecoratedSurface<H>
+    where H: decorated_surface::Handler,
+{
+    unsafe fn message(
+        &mut self,
+        evq: &mut EventQueueHandle,
+        proxy: &ZxdgSurfaceV6,
+        opcode: u32,
+        args: *const wayland_client::sys::wl_argument,
+    ) -> Result<(),()>
+    {
+        <DecoratedSurface<H> as xdg_shell::client::zxdg_surface_v6::Handler>::__message(
+            self, evq, proxy, opcode, args
+        )
+    }
+}
+
+impl<H> xdg_shell::client::zxdg_toplevel_v6::Handler for DecoratedSurface<H>
+    where H: decorated_surface::Handler,
+{
+
+    fn configure(
+        &mut self,
+        evqh: &mut EventQueueHandle,
+        _proxy: &ZxdgToplevelV6,
+        width: i32, height: i32,
+        _states: Vec<u8>,
+    ) {
+        // NOTE: Not sure if/how `_states` should be handled here.
+        if let Some(handler) = decorated_surface::handler_mut(self) {
+            let (w, h) = decorated_surface::subtract_borders(width, height);
+            let configure = super::Configure::Xdg;
+            handler.configure(evqh, configure, max(w, 1), max(h, 1));
+        }
+    }
+
+    fn close(&mut self, _evqh: &mut EventQueueHandle, _proxy: &ZxdgToplevelV6) {
+        // NOTE: Should there be a method on `Handler` for this?
+    }
+}
+
+impl<H> xdg_shell::client::zxdg_surface_v6::Handler for DecoratedSurface<H>
+    where H: decorated_surface::Handler,
+{
+
+    fn configure(
+        &mut self,
+        _evqh: &mut EventQueueHandle,
+        _proxy: &ZxdgSurfaceV6,
+        serial: u32,
+    ) {
+        if let super::Surface::Xdg(ref xdg) = *decorated_surface::shell_surface(self) {
+            xdg.surface.ack_configure(serial).expect("surface cannot be destroyed");
+        }
+    }
+
+}


### PR DESCRIPTION
So far this commit mostly attempts to replace `wl_shell` with `xdg_shell` in order to simplify integration of `xdg_shell` for myself. The plan is to re-integrate support for `wl_shell` and move all `xdg_shell` functionality behind a (defaulted) feature gate in a future commit to allow for backward-compatibility with `wl_shell`.

Several xdg_surface methods have not yet been exposed in the `DecoratedSurface` API including set_api_id, minimize, etc.

@vberger Although this commit replaces usage of `wl_shell` with `xdg_shell` in the example, I'm finding that I still have the exact same problems that I had before mentioned in #16 - `configure` is still not being called by the mutter (v3.22.3) compositor during resizing or moving, even though it seems to work perfectly fine on weston (v2.0.0). This makes me wonder if the issue is perhaps not related to xdg_shell, and perhaps some other difference between the mutter and weston compositors? On the other hand, maybe I just haven't integrated `xdg_shell` properly?

I decided to run the example on both mutter and wayland to compare the output of `WAYLAND_DEBUG=1` to see if I could spot any differences. I found only two:

The first difference was the very start of the log where globals are registered:

**weston**
```
[3812751.543] wl_registry@2.global(1, "wl_compositor", 4)
[3812751.554] wl_registry@2.global(2, "wl_subcompositor", 1)
[3812751.561] wl_registry@2.global(3, "wp_viewporter", 1)
[3812751.568] wl_registry@2.global(4, "wp_presentation", 1)
[3812751.584] wl_registry@2.global(5, "zwp_relative_pointer_manager_v1", 1)
[3812751.593] wl_registry@2.global(6, "zwp_pointer_constraints_v1", 1)
[3812751.602] wl_registry@2.global(7, "wl_data_device_manager", 3)
[3812751.612] wl_registry@2.global(8, "wl_shm", 1)
[3812751.623] wl_registry@2.global(9, "wl_seat", 5)
[3812751.637] wl_registry@2.global(10, "wl_drm", 2)
[3812751.647] wl_registry@2.global(11, "zwp_linux_dmabuf_v1", 1)
[3812751.658] wl_registry@2.global(12, "wl_output", 3)
[3812751.668] wl_registry@2.global(13, "zwp_input_panel_v1", 1)
[3812751.679] wl_registry@2.global(14, "zwp_input_method_v1", 1)
[3812751.691] wl_registry@2.global(15, "zwp_text_input_manager_v1", 1)
[3812751.702] wl_registry@2.global(16, "zxdg_shell_v6", 1)
[3812751.714]  -> wl_registry@2.bind(1, "wl_compositor", 4, new id [unknown]@4)
[3812751.749]  -> wl_registry@2.bind(2, "wl_subcompositor", 1, new id [unknown]@5)
[3812751.762]  -> wl_registry@2.bind(8, "wl_shm", 1, new id [unknown]@6)
[3812751.771]  -> wl_registry@2.bind(16, "zxdg_shell_v6", 1, new id [unknown]@7)
[3812751.798] wl_registry@2.global(17, "xdg_shell", 1)
[3812751.805] wl_registry@2.global(18, "wl_shell", 1)
[3812751.811] wl_registry@2.global(19, "weston_desktop_shell", 1)
[3812751.818] wl_registry@2.global(20, "weston_screenshooter", 1)
```
**mutter**
```
[2095686.583] wl_registry@2.global(1, "wl_drm", 2)
[2095686.598] wl_registry@2.global(2, "wl_compositor", 3)
[2095686.606] wl_registry@2.global(3, "wl_shm", 1)
[2095686.616] wl_registry@2.global(5, "wl_output", 2)
[2095686.640] wl_registry@2.global(6, "wl_data_device_manager", 3)
[2095686.652] wl_registry@2.global(7, "gtk_primary_selection_device_manager", 1)
[2095686.662] wl_registry@2.global(8, "zxdg_shell_v6", 1)
[2095686.675] wl_registry@2.global(9, "wl_shell", 1)
[2095686.687] wl_registry@2.global(10, "gtk_shell1", 1)
[2095686.699] wl_registry@2.global(11, "wl_subcompositor", 1)
[2095686.715]  -> wl_registry@2.bind(2, "wl_compositor", 3, new id [unknown]@4)
[2095686.728]  -> wl_registry@2.bind(11, "wl_subcompositor", 1, new id [unknown]@5)
[2095686.746]  -> wl_registry@2.bind(3, "wl_shm", 1, new id [unknown]@6)
[2095686.758]  -> wl_registry@2.bind(8, "zxdg_shell_v6", 1, new id [unknown]@7)
[2095686.774] wl_registry@2.global(12, "zwp_pointer_gestures_v1", 1)
[2095686.784] wl_registry@2.global(13, "zwp_tablet_manager_v2", 1)
[2095686.792] wl_registry@2.global(14, "wl_seat", 5)
[2095686.800] wl_registry@2.global(15, "zwp_relative_pointer_manager_v1", 1)
[2095686.810] wl_registry@2.global(16, "zwp_pointer_constraints_v1", 1)
[2095686.819] wl_registry@2.global(17, "zxdg_exporter_v1", 1)
[2095686.826] wl_registry@2.global(18, "zxdg_importer_v1", 1)
```

The main difference I noticed between these two (besides the ordering which I assume does not matter) is that weston registers a "xdg_shell", "weston_desktop_shell" and "weston_screenshooter" globals whereas mutter does not, but does register a "gtk_shell1" global. Does it seem strange to you that the mutter compositor does not register "xdg_shell" like weston does?

The second and only other difference I noticed (besides `configure` not being called during resize) was that weston used the `surface.damage_buffer` method to indicate surface damage when the `ThemedPointer` hovered over the resizable edge, whereas mutter used the `surface.damage` method. I found the related code [here](https://github.com/vberger/wayland-window/blob/master/src/themed_pointer.rs#L43-L49). This seems to indicate that mutter uses a pre-4 version of surface. Could this be related?